### PR TITLE
Add a feature that allows URLs to be used only once

### DIFF
--- a/config-sample.php
+++ b/config-sample.php
@@ -69,3 +69,6 @@ define('CACHE', TRUE);
 
 // if so, where will the cache files be stored? (include trailing slash)
 define('CACHE_DIR', dirname(__FILE__) . '/cache/');
+
+// all URLS will be one-use only. Requires TRACK to be set to true
+define('THROWAWAY_URLS', true);


### PR DESCRIPTION
Since the shortened URLs are numbered sequentially, there is a risk if the URLs are used for something sensitive. It would allow anyone who has one URL to track back and get all the other URLs previously used. To prevent that, I added a option to use every URL only once.

It requires TRACK to be enabled so the system knows which link has been accessed already.
